### PR TITLE
Add initial Quail ingest scaffolding and repo layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
-# quail
-private lite mail sink
-See QUAIL_CODEX_CONTEXT.md for authoritative project requirements.
+# Quail
+
+Quail is a self-hosted, receive-only mail sink for CST QA/dev teams. It accepts
+inbound mail on `m.cst.ro` and exposes a private shared inbox UI. See
+`QUAIL_CODEX_CONTEXT.md` for the authoritative requirements and constraints.
+
+## Status
+
+Initial repository scaffolding and ingest pipeline are in place. The FastAPI UI,
+retention purge job, and install/upgrade automation are stubbed with TODOs.
+
+## Ingest
+
+Postfix should pipe messages to `scripts/quail-ingest`, which runs the ingest
+module and stores raw `.eml` files plus metadata in SQLite.
+
+## Configuration
+
+Copy `config/config.example.env` to `/etc/quail/config.env` and adjust values as
+needed.

--- a/config/config.example.env
+++ b/config/config.example.env
@@ -1,0 +1,6 @@
+# Quail configuration
+QUAIL_DATA_DIR=/var/lib/quail
+QUAIL_EML_DIR=/var/lib/quail/eml
+QUAIL_ATTACHMENT_DIR=/var/lib/quail/att
+QUAIL_DB_PATH=/var/lib/quail/quail.db
+QUAIL_MAX_MESSAGE_SIZE_MB=10

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# TODO: implement idempotent install steps per QUAIL_CODEX_CONTEXT.md.
+# This script should install system packages, create the quail user,
+# create /var/lib/quail/{eml,att}, set up the Python venv, install
+# dependencies, install Postfix snippets without clobbering, and
+# enable systemd units.
+
+echo "Quail install placeholder. TODO: implement." >&2

--- a/postfix/maincf.snippet
+++ b/postfix/maincf.snippet
@@ -1,0 +1,3 @@
+# Quail catch-all transport
+virtual_alias_domains = m.cst.ro
+virtual_alias_maps = hash:/etc/postfix/virtual

--- a/postfix/mastercf_pipe.snippet
+++ b/postfix/mastercf_pipe.snippet
@@ -1,0 +1,2 @@
+quail unix - n n - - pipe
+  flags=Rq user=quail argv=/opt/quail/scripts/quail-ingest ${recipient}

--- a/postfix/virtual
+++ b/postfix/virtual
@@ -1,0 +1,2 @@
+# Catch-all mapping for m.cst.ro
+@m.cst.ro quail

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "quail"
+version = "0.1.0"
+description = "Self-hosted, receive-only mail sink"
+readme = "README.md"
+requires-python = ">=3.11"
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100

--- a/quail/__init__.py
+++ b/quail/__init__.py
@@ -1,0 +1,1 @@
+"""Quail package."""

--- a/quail/db.py
+++ b/quail/db.py
@@ -1,0 +1,74 @@
+"""SQLite helpers for Quail."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable
+
+
+SCHEMA = [
+    """
+    CREATE TABLE IF NOT EXISTS messages (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        received_at TEXT NOT NULL,
+        envelope_rcpt TEXT NOT NULL,
+        from_addr TEXT,
+        subject TEXT,
+        date TEXT,
+        message_id TEXT,
+        size_bytes INTEGER NOT NULL,
+        eml_path TEXT NOT NULL,
+        quarantined INTEGER NOT NULL DEFAULT 0
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS settings (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS admin_actions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        action TEXT NOT NULL,
+        source_ip TEXT NOT NULL,
+        performed_at TEXT NOT NULL
+    )
+    """,
+]
+
+
+def get_connection(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with get_connection(db_path) as conn:
+        for statement in SCHEMA:
+            conn.execute(statement)
+        conn.commit()
+
+
+def get_setting(db_path: Path, key: str) -> str | None:
+    with get_connection(db_path) as conn:
+        row = conn.execute("SELECT value FROM settings WHERE key = ?", (key,)).fetchone()
+        return row["value"] if row else None
+
+
+def set_setting(db_path: Path, key: str, value: str) -> None:
+    with get_connection(db_path) as conn:
+        conn.execute(
+            "INSERT INTO settings (key, value) VALUES (?, ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (key, value),
+        )
+        conn.commit()
+
+
+def iter_settings(db_path: Path) -> Iterable[sqlite3.Row]:
+    with get_connection(db_path) as conn:
+        yield from conn.execute("SELECT key, value FROM settings ORDER BY key")

--- a/quail/ingest.py
+++ b/quail/ingest.py
@@ -1,0 +1,142 @@
+"""Postfix pipe ingest for Quail."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from email import policy
+from email.parser import BytesParser
+from pathlib import Path
+from typing import Iterable
+from uuid import uuid4
+
+from quail import db
+from quail.logging_config import configure_logging
+from quail.settings import get_settings
+
+LOGGER = logging.getLogger(__name__)
+DEFAULT_ALLOWED_MIME_TYPES = ("application/pdf",)
+SETTINGS_ALLOWED_MIME_KEY = "allowed_attachment_mime_types"
+
+
+def _parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Quail ingest")
+    parser.add_argument(
+        "envelope_rcpt",
+        nargs="?",
+        default=os.getenv("QUAIL_RCPT", ""),
+        help="Envelope recipient provided by Postfix",
+    )
+    return parser.parse_args(list(argv))
+
+
+def _allowed_mime_types(db_path: Path) -> set[str]:
+    value = db.get_setting(db_path, SETTINGS_ALLOWED_MIME_KEY)
+    if not value:
+        db.set_setting(db_path, SETTINGS_ALLOWED_MIME_KEY, ",".join(DEFAULT_ALLOWED_MIME_TYPES))
+        return set(DEFAULT_ALLOWED_MIME_TYPES)
+    return {item.strip().lower() for item in value.split(",") if item.strip()}
+
+
+def _message_has_disallowed_attachments(raw_bytes: bytes, allowed_types: set[str]) -> bool:
+    message = BytesParser(policy=policy.default).parsebytes(raw_bytes)
+    for part in message.walk():
+        filename = part.get_filename()
+        disposition = part.get_content_disposition()
+        if disposition == "attachment" or filename:
+            content_type = part.get_content_type().lower()
+            if content_type not in allowed_types:
+                return True
+    return False
+
+
+def _extract_metadata(raw_bytes: bytes) -> dict[str, str | None]:
+    message = BytesParser(policy=policy.default).parsebytes(raw_bytes)
+    return {
+        "from_addr": message.get("From"),
+        "subject": message.get("Subject"),
+        "date": message.get("Date"),
+        "message_id": message.get("Message-ID"),
+    }
+
+
+def _write_eml(raw_bytes: bytes, eml_dir: Path) -> Path:
+    eml_dir.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    filename = f"{timestamp}_{uuid4().hex}.eml"
+    eml_path = eml_dir / filename
+    eml_path.write_bytes(raw_bytes)
+    return eml_path
+
+
+def ingest(raw_bytes: bytes, envelope_rcpt: str) -> None:
+    settings = get_settings()
+    db.init_db(settings.db_path)
+
+    eml_path = _write_eml(raw_bytes, settings.eml_dir)
+    metadata = _extract_metadata(raw_bytes)
+    allowed_types = _allowed_mime_types(settings.db_path)
+    quarantined = _message_has_disallowed_attachments(raw_bytes, allowed_types)
+
+    with db.get_connection(settings.db_path) as conn:
+        conn.execute(
+            """
+            INSERT INTO messages (
+                received_at,
+                envelope_rcpt,
+                from_addr,
+                subject,
+                date,
+                message_id,
+                size_bytes,
+                eml_path,
+                quarantined
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                datetime.now(tz=timezone.utc).isoformat(),
+                envelope_rcpt,
+                metadata["from_addr"],
+                metadata["subject"],
+                metadata["date"],
+                metadata["message_id"],
+                len(raw_bytes),
+                str(eml_path),
+                1 if quarantined else 0,
+            ),
+        )
+        conn.commit()
+
+    if quarantined:
+        LOGGER.warning("Message quarantined due to disallowed attachment types.")
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    configure_logging()
+    args = _parse_args(argv or sys.argv[1:])
+
+    raw_bytes = sys.stdin.buffer.read()
+    if not raw_bytes:
+        LOGGER.error("No email content received on stdin.")
+        return 1
+
+    settings = get_settings()
+    max_bytes = settings.max_message_size_mb * 1024 * 1024
+    if len(raw_bytes) > max_bytes:
+        LOGGER.warning(
+            "Message size %s exceeds configured max %s MB.",
+            len(raw_bytes),
+            settings.max_message_size_mb,
+        )
+
+    envelope_rcpt = args.envelope_rcpt or "unknown"
+    ingest(raw_bytes, envelope_rcpt)
+    LOGGER.info("Message ingested for recipient %s.", envelope_rcpt)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quail/logging_config.py
+++ b/quail/logging_config.py
@@ -1,0 +1,12 @@
+"""Logging configuration for Quail."""
+
+from __future__ import annotations
+
+import logging
+
+
+DEFAULT_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    logging.basicConfig(level=level, format=DEFAULT_FORMAT)

--- a/quail/purge.py
+++ b/quail/purge.py
@@ -1,0 +1,15 @@
+"""Retention purge job for Quail."""
+
+from __future__ import annotations
+
+from quail.logging_config import configure_logging
+
+
+def main() -> int:
+    configure_logging()
+    # TODO: implement retention purge job.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quail/security.py
+++ b/quail/security.py
@@ -1,0 +1,16 @@
+"""Security helpers for Quail."""
+
+from __future__ import annotations
+
+from argon2 import PasswordHasher
+
+
+_PASSWORD_HASHER = PasswordHasher()
+
+
+def hash_pin(pin: str) -> str:
+    return _PASSWORD_HASHER.hash(pin)
+
+
+def verify_pin(pin: str, stored_hash: str) -> bool:
+    return _PASSWORD_HASHER.verify(stored_hash, pin)

--- a/quail/settings.py
+++ b/quail/settings.py
@@ -1,0 +1,35 @@
+"""Configuration helpers for Quail."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Settings:
+    data_dir: Path
+    eml_dir: Path
+    attachment_dir: Path
+    db_path: Path
+    max_message_size_mb: int
+
+
+DEFAULT_DATA_DIR = Path(os.getenv("QUAIL_DATA_DIR", "/var/lib/quail"))
+DEFAULT_EML_DIR = Path(os.getenv("QUAIL_EML_DIR", str(DEFAULT_DATA_DIR / "eml")))
+DEFAULT_ATTACHMENT_DIR = Path(
+    os.getenv("QUAIL_ATTACHMENT_DIR", str(DEFAULT_DATA_DIR / "att"))
+)
+DEFAULT_DB_PATH = Path(os.getenv("QUAIL_DB_PATH", str(DEFAULT_DATA_DIR / "quail.db")))
+DEFAULT_MAX_MESSAGE_SIZE_MB = int(os.getenv("QUAIL_MAX_MESSAGE_SIZE_MB", "10"))
+
+
+def get_settings() -> Settings:
+    return Settings(
+        data_dir=DEFAULT_DATA_DIR,
+        eml_dir=DEFAULT_EML_DIR,
+        attachment_dir=DEFAULT_ATTACHMENT_DIR,
+        db_path=DEFAULT_DB_PATH,
+        max_message_size_mb=DEFAULT_MAX_MESSAGE_SIZE_MB,
+    )

--- a/quail/templates/admin_settings.html
+++ b/quail/templates/admin_settings.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Admin Settings</h1>
+<p>TODO: settings form.</p>
+{% endblock %}

--- a/quail/templates/admin_unlock.html
+++ b/quail/templates/admin_unlock.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Admin Unlock</h1>
+<p>TODO: prompt for PIN.</p>
+{% endblock %}

--- a/quail/templates/inbox.html
+++ b/quail/templates/inbox.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Inbox</h1>
+<p>TODO: render messages.</p>
+{% endblock %}

--- a/quail/templates/layout.html
+++ b/quail/templates/layout.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Quail</title>
+  </head>
+  <body>
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/quail/templates/message.html
+++ b/quail/templates/message.html
@@ -1,0 +1,5 @@
+{% extends "layout.html" %}
+{% block content %}
+<h1>Message</h1>
+<p>TODO: render message.</p>
+{% endblock %}

--- a/quail/web.py
+++ b/quail/web.py
@@ -1,0 +1,20 @@
+"""FastAPI entrypoint for Quail UI and API."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from quail.logging_config import configure_logging
+
+app = FastAPI(title="Quail")
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    configure_logging()
+    # TODO: load settings, ensure DB initialized, and wire routes.
+
+
+@app.get("/healthz")
+async def healthz() -> dict[str, str]:
+    return {"status": "ok"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn==0.30.1
+jinja2==3.1.4
+python-multipart==0.0.9
+argon2-cffi==23.1.0

--- a/scripts/quail-ingest
+++ b/scripts/quail-ingest
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+exec /usr/bin/env python3 -m quail.ingest "$@"

--- a/systemd/quail-purge.service
+++ b/systemd/quail-purge.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Quail retention purge
+
+[Service]
+Type=oneshot
+User=quail
+Group=quail
+WorkingDirectory=/opt/quail
+EnvironmentFile=-/etc/quail/config.env
+ExecStart=/opt/quail/venv/bin/python -m quail.purge

--- a/systemd/quail-purge.timer
+++ b/systemd/quail-purge.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Quail daily retention purge
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/quail.service
+++ b/systemd/quail.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Quail web service
+After=network.target
+
+[Service]
+Type=simple
+User=quail
+Group=quail
+WorkingDirectory=/opt/quail
+EnvironmentFile=-/etc/quail/config.env
+ExecStart=/opt/quail/venv/bin/uvicorn quail.web:app --host 127.0.0.1 --port 8000
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# TODO: implement idempotent upgrade steps per QUAIL_CODEX_CONTEXT.md.
+# This script should update dependencies and restart services without
+# deleting stored mail or modifying retention/admin data.
+
+echo "Quail upgrade placeholder. TODO: implement." >&2


### PR DESCRIPTION
### Motivation
- Implement the ingest pipeline required by `QUAIL_CODEX_CONTEXT.md` to accept Postfix-piped mail and persist raw `.eml` as the source of truth.
- Extract and record core metadata (envelope recipient, From, Subject, Date, Message-ID, size) into SQLite for a shared inbox model.
- Provide safe-by-default handling for attachments (PDF-only default) and quarantine messages with disallowed attachment types rather than rejecting at SMTP.
- Create initial repository, deployment, and UI scaffolding so one operator can install and run the service with further implementation remaining as TODOs.

### Description
- Add `quail/ingest.py` implementing `ingest()` plus helpers to write `.eml` files (`_write_eml`), extract headers (`_extract_metadata`), check attachment MIME types and mark quarantined messages, and wire into the SQLite DB.
- Add `quail/db.py` with SQLite schema and helpers (`init_db`, `get_connection`, `get_setting`, `set_setting`, `iter_settings`) and `quail/settings.py` to centralize paths and defaults.
- Add supporting modules and assets: `quail/security.py`, `quail/logging_config.py`, `quail/web.py` (FastAPI entrypoint with `/healthz`), Jinja2 templates under `quail/templates/`, and deployment scaffolding including `scripts/quail-ingest`, `systemd/*` units, and `postfix/*` snippets.
- Add packaging and config files: `requirements.txt`, `pyproject.toml`, `config/config.example.env`, and placeholder `install.sh`/`upgrade.sh` and TODOs where further implementation is required.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa9942f948326847ef96781c9edf6)