### PR TITLE
Implement idempotent install and upgrade scripts

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,10 +1,84 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# TODO: implement idempotent install steps per QUAIL_CODEX_CONTEXT.md.
-# This script should install system packages, create the quail user,
-# create /var/lib/quail/{eml,att}, set up the Python venv, install
-# dependencies, install Postfix snippets without clobbering, and
-# enable systemd units.
+INSTALL_DIR="/opt/quail"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Quail install placeholder. TODO: implement." >&2
+if [[ ${EUID} -ne 0 ]]; then
+  echo "ERROR: install.sh must be run as root." >&2
+  exit 1
+fi
+
+if [[ "${SCRIPT_DIR}" != "${INSTALL_DIR}" ]]; then
+  if [[ ! -d "${INSTALL_DIR}" ]]; then
+    echo "ERROR: expected Quail repo at ${INSTALL_DIR}." >&2
+    echo "TODO: clone this repository to ${INSTALL_DIR} before running install." >&2
+    exit 1
+  fi
+fi
+
+if command -v apt-get >/dev/null 2>&1; then
+  apt-get update -y
+  apt-get install -y python3-venv python3-pip postfix
+else
+  echo "ERROR: unsupported package manager. TODO: install python3-venv, python3-pip, postfix." >&2
+  exit 1
+fi
+
+if ! id -u quail >/dev/null 2>&1; then
+  useradd --system --home /var/lib/quail --shell /usr/sbin/nologin quail
+fi
+
+install -d -o quail -g quail -m 0750 /var/lib/quail /var/lib/quail/eml /var/lib/quail/att
+
+if [[ ! -d "${INSTALL_DIR}/venv" ]]; then
+  python3 -m venv "${INSTALL_DIR}/venv"
+fi
+
+"${INSTALL_DIR}/venv/bin/pip" install --upgrade pip
+"${INSTALL_DIR}/venv/bin/pip" install -r "${INSTALL_DIR}/requirements.txt"
+
+if [[ ! -f /etc/postfix/virtual ]]; then
+  printf '%s\n' "# Quail catch-all mapping for m.cst.ro" > /etc/postfix/virtual
+fi
+if ! grep -Fxq "@m.cst.ro quail" /etc/postfix/virtual; then
+  printf '%s\n' "@m.cst.ro quail" >> /etc/postfix/virtual
+fi
+
+if command -v postconf >/dev/null 2>&1; then
+  virtual_alias_domains="$(postconf -h virtual_alias_domains || true)"
+  if [[ -z "${virtual_alias_domains}" ]]; then
+    postconf -e "virtual_alias_domains = m.cst.ro"
+  elif [[ "${virtual_alias_domains}" != *"m.cst.ro"* ]]; then
+    echo "WARNING: virtual_alias_domains is already set; update manually to include m.cst.ro." >&2
+  fi
+
+  virtual_alias_maps="$(postconf -h virtual_alias_maps || true)"
+  if [[ -z "${virtual_alias_maps}" ]]; then
+    postconf -e "virtual_alias_maps = hash:/etc/postfix/virtual"
+  elif [[ "${virtual_alias_maps}" != *"/etc/postfix/virtual"* ]]; then
+    echo "WARNING: virtual_alias_maps is already set; update manually to include /etc/postfix/virtual." >&2
+  fi
+else
+  echo "ERROR: postconf not found; ensure postfix is installed." >&2
+  exit 1
+fi
+
+if ! grep -q "^quail\s" /etc/postfix/master.cf; then
+  cat "${INSTALL_DIR}/postfix/mastercf_pipe.snippet" >> /etc/postfix/master.cf
+fi
+
+postmap /etc/postfix/virtual
+if command -v systemctl >/dev/null 2>&1; then
+  systemctl reload postfix || systemctl restart postfix
+fi
+
+install -m 0644 "${INSTALL_DIR}/systemd/quail.service" /etc/systemd/system/quail.service
+install -m 0644 "${INSTALL_DIR}/systemd/quail-purge.service" /etc/systemd/system/quail-purge.service
+install -m 0644 "${INSTALL_DIR}/systemd/quail-purge.timer" /etc/systemd/system/quail-purge.timer
+
+systemctl daemon-reload
+systemctl enable --now quail.service
+systemctl enable --now quail-purge.timer
+
+echo "Quail install complete."

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -1,8 +1,31 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# TODO: implement idempotent upgrade steps per QUAIL_CODEX_CONTEXT.md.
-# This script should update dependencies and restart services without
-# deleting stored mail or modifying retention/admin data.
+INSTALL_DIR="/opt/quail"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-echo "Quail upgrade placeholder. TODO: implement." >&2
+if [[ ${EUID} -ne 0 ]]; then
+  echo "ERROR: upgrade.sh must be run as root." >&2
+  exit 1
+fi
+
+if [[ "${SCRIPT_DIR}" != "${INSTALL_DIR}" ]]; then
+  if [[ ! -d "${INSTALL_DIR}" ]]; then
+    echo "ERROR: expected Quail repo at ${INSTALL_DIR}." >&2
+    echo "TODO: clone this repository to ${INSTALL_DIR} before running upgrade." >&2
+    exit 1
+  fi
+fi
+
+if [[ ! -d "${INSTALL_DIR}/venv" ]]; then
+  python3 -m venv "${INSTALL_DIR}/venv"
+fi
+
+"${INSTALL_DIR}/venv/bin/pip" install --upgrade pip
+"${INSTALL_DIR}/venv/bin/pip" install -r "${INSTALL_DIR}/requirements.txt"
+
+systemctl daemon-reload
+systemctl restart quail.service
+systemctl restart quail-purge.timer
+
+echo "Quail upgrade complete."


### PR DESCRIPTION
### Motivation
- Replace placeholder installers with idempotent, safe install/upgrade steps per `QUAIL_CODEX_CONTEXT.md` requirements.
- Ensure system packages, service user, storage directories, Python venv, Postfix snippets, and systemd units are created/configured without clobbering existing data.
- Provide an upgrade path that refreshes dependencies and restarts services without deleting mail or modifying retention/admin data.

### Description
- Implement `install.sh` with root and install-path checks and idempotent steps to install OS packages (`apt-get`), create the `quail` system user, and create `/var/lib/quail/eml` and `/var/lib/quail/att` with correct ownership and permissions.
- Create and populate a Python virtualenv at `/opt/quail/venv` and install pinned dependencies via `pip` from `requirements.txt`.
- Configure Postfix safely by appending the virtual mapping to `/etc/postfix/virtual`, setting `virtual_alias_domains`/`virtual_alias_maps` with `postconf` when unset (and warning when values conflict), appending the `master.cf` pipe snippet only when missing, running `postmap`, and reloading Postfix.
- Install and enable `systemd` units from `systemd/` (`quail.service`, `quail-purge.service`, `quail-purge.timer`) and implement `upgrade.sh` which refreshes the venv dependencies and cleanly restarts `quail.service` and the purge timer without touching stored mail or retention/admin data.

### Testing
- No automated tests were run for these script changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fb18849f4832689ed152f6962aa2c)