### PR TITLE
Fix admin unlock form layout

### DIFF
--- a/quail/templates/admin_unlock.html
+++ b/quail/templates/admin_unlock.html
@@ -6,17 +6,11 @@
 {% elif error == "rate_limited" %}
 <p>Too many attempts. Please wait a few minutes.</p>
 {% endif %}
-<form method="post" action="/admin/unlock">
-  <label for="pin">Admin PIN</label>
-  <input id="pin" name="pin" type="password" required />
-{% if error %}
-<p class="error">{{ error }}</p>
-{% endif %}
 {% if not pin_configured %}
 <p>Admin PIN is not configured yet.</p>
 {% endif %}
-<form method="post">
-  <label for="pin">PIN</label>
+<form method="post" action="/admin/unlock">
+  <label for="pin">Admin PIN</label>
   <input id="pin" name="pin" type="password" autocomplete="current-password" required />
   <button type="submit">Unlock</button>
 </form>


### PR DESCRIPTION
### Motivation
- Ensure the admin unlock page renders as valid, minimal HTML with a single POST form for unlocking.
- Remove duplicated and nested PIN input elements that could confuse browsers or lead to invalid markup.
- Render error and configuration messages exactly once to avoid duplicate messaging in the UI.
- Keep the UI minimal and consistent with the single shared admin PIN model.

### Description
- Updated `quail/templates/admin_unlock.html` to remove the nested/duplicate `<form>` and extra PIN field. 
- Consolidated error handling so messages like `invalid`, `rate_limited`, and the `pin_configured` notice are rendered once above the form.
- Left a single `<form method="post" action="/admin/unlock">` with the `pin` input using `autocomplete="current-password"` and a submit `Unlock` button.
- Kept the existing template inheritance (`layout.html`) and block structure intact.

### Testing
- No automated tests were executed for this template-only change.
- A local file check verified the updated template was saved and contains a single valid form element.
- No test failures were observed because no tests were run.
- TODO: Add template rendering test in CI to validate Jinja2 template output in future changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc365b7548326bd377823082460f7)