### PR TITLE
Consolidate admin settings form

### DIFF
--- a/quail/templates/admin_settings.html
+++ b/quail/templates/admin_settings.html
@@ -27,30 +27,4 @@
   <button type="submit">Save settings</button>
 </form>
 <p><a href="/inbox">Back to inbox</a></p>
-{% if error %}
-  <p style="color: red;">{{ error }}</p>
-{% endif %}
-<form method="post">
-  <label for="retention_days">Retention days</label>
-  <input
-    id="retention_days"
-    name="retention_days"
-    type="number"
-    min="1"
-    required
-    value="{{ retention_days }}"
-  />
-<form method="post">
-  <label for="allowed_attachment_mime_types">
-    Allowed attachment MIME types (comma-separated)
-  </label>
-  <input
-    id="allowed_attachment_mime_types"
-    name="allowed_attachment_mime_types"
-    type="text"
-    value="{{ allowed_attachment_mime_types }}"
-  />
-  <p>Default: application/pdf</p>
-  <button type="submit">Save</button>
-</form>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Present a single admin settings form that contains allowed MIME types, retention days, an HTML toggle, and an optional admin PIN update.
- Remove duplicated form blocks and nested `<form>` tags that caused confusing UI and duplicate inputs.
- Keep success and error messages driven by query parameters (`updated`, `error`) in one place for consistent feedback.

### Description
- Edited `quail/templates/admin_settings.html` to consolidate all settings into one form targeted at `/admin/settings`.
- Removed the duplicate/nested form blocks and duplicate fields (`allowed_attachment_mime_types` / extra `retention_days`).
- Ensured the single form includes `allowed_mime_types`, `retention_days`, `allow_html` (checkbox), and `admin_pin` (password) inputs.
- Preserved the query-parameter status messages for `updated` and `error=retention` at the top of the template.

### Testing
- No automated tests were run for this template-only change.
- Change is limited to `quail/templates/admin_settings.html` and expected to be low risk (render-only adjustment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc3670fcc832680ba55ac91774af1)