### PR TITLE
Simplify inbox empty state

### DIFF
--- a/quail/templates/inbox.html
+++ b/quail/templates/inbox.html
@@ -31,20 +31,4 @@
 </table>
 {% else %}
 <p>No messages yet.</p>
-{% if messages %}
-  <ul>
-  {% for message in messages %}
-    <li>
-      <strong>{{ message.subject or "(no subject)" }}</strong>
-      from {{ message.from_addr or "unknown" }}
-      <em>{{ message.received_at }}</em>
-      {% if is_admin and message.quarantined %}
-        <span>(quarantined)</span>
-      {% endif %}
-    </li>
-  {% endfor %}
-  </ul>
-{% else %}
-  <p>No messages yet.</p>
-{% endif %}
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Ensure the inbox template has a single clear branch for when messages exist and a single else branch that shows an empty-state message.
- Remove duplicated/nested conditional logic which produced redundant markup and duplicated "No messages yet." output.
- Improve maintainability and reduce the risk of inconsistent display between list and table render paths.

### Description
- Update `quail/templates/inbox.html` to remove the nested `{% if messages %}` block inside the `else` and keep one `if messages` branch with the table and one `else` with a single `<p>No messages yet.</p>`.
- Preserve the existing table rendering and admin/quarantine column logic under the primary `{% if messages %}` branch.
- Remove the duplicated unordered-list rendering and the extra duplicate empty-state paragraph.

### Testing
- No automated tests were run because this is a template-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc3681390832681498dde9a14489e)