### PR TITLE
Consolidate purge implementation in quail/purge.py

### DIFF
--- a/quail/purge.py
+++ b/quail/purge.py
@@ -67,79 +67,6 @@ def _purge_messages(db_path: Path, cutoff: datetime) -> int:
             purged += 1
         conn.commit()
         return purged
-import os
-from datetime import datetime, timedelta, timezone
-from pathlib import Path
-
-from quail.logging_config import configure_logging
-from quail import db
-from quail.settings import get_settings
-
-
-LOGGER = logging.getLogger(__name__)
-RETENTION_KEY = "retention_days"
-DEFAULT_RETENTION_DAYS = 30
-
-
-def _get_retention_days(db_path: Path) -> int:
-    """Retrieve the retention period from the settings table.
-
-    If no value is configured the default is written to the database.
-
-    Parameters
-    ----------
-    db_path: Path
-        Database path.
-
-    Returns
-    -------
-    int
-        Number of days to retain messages.
-    """
-    value = db.get_setting(db_path, RETENTION_KEY)
-    if value is None:
-        db.set_setting(db_path, RETENTION_KEY, str(DEFAULT_RETENTION_DAYS))
-        return DEFAULT_RETENTION_DAYS
-    try:
-        days = int(value)
-        return days if days > 0 else DEFAULT_RETENTION_DAYS
-    except ValueError:
-        LOGGER.warning("Invalid retention_days setting %s; using default %s", value, DEFAULT_RETENTION_DAYS)
-        return DEFAULT_RETENTION_DAYS
-
-
-def purge_expired_messages() -> int:
-    """Purge messages older than the configured retention period.
-
-    Returns
-    -------
-    int
-        Number of messages purged.
-    """
-    settings = get_settings()
-    db.init_db(settings.db_path)
-    retention_days = _get_retention_days(settings.db_path)
-    cutoff = datetime.now(tz=timezone.utc) - timedelta(days=retention_days)
-    cutoff_iso = cutoff.isoformat()
-
-    deleted_count = 0
-    with db.get_connection(settings.db_path) as conn:
-        rows = list(
-            conn.execute(
-                "SELECT id, eml_path FROM messages WHERE received_at < ?",
-                (cutoff_iso,),
-            )
-        )
-        for row in rows:
-            eml_path = Path(row["eml_path"])
-            try:
-                os.remove(eml_path)
-            except FileNotFoundError:
-                LOGGER.debug("EML file %s already removed", eml_path)
-            conn.execute("DELETE FROM messages WHERE id = ?", (row["id"],))
-            deleted_count += 1
-        conn.commit()
-    return deleted_count
 
 
 def main() -> int:
@@ -168,8 +95,6 @@ def main() -> int:
         purged_messages,
         purged_attachments,
     )
-    purged = purge_expired_messages()
-    LOGGER.info("Purged %s expired messages", purged)
     return 0
 
 


### PR DESCRIPTION
### Motivation
- Remove a duplicated retention purge implementation to avoid double-deletes and inconsistent DB operations.
- Ensure the purge job reads retention using `get_retention_days` and applies a single canonical flow.
- Keep `.eml` file deletion, attachment cleanup, and database row removal performed exactly once.
- Reduce redundant imports and stray helper functions to simplify maintenance.

### Description
- Consolidated logic in `quail/purge.py` to a single purge path and removed the duplicate `_get_retention_days`/`purge_expired_messages` implementation.
- Retained and used helper functions `_delete_eml`, `_purge_old_attachments`, and `_purge_messages`, and ensured `main()` initializes DB and calls the canonical purge flow using `get_retention_days`.
- Removed duplicate imports and unused helper code so message `.eml` files, attachments, and DB rows are cleaned up in one place.
- Updated logging path in `main()` to report retention days, purged messages, and attachments.

### Testing
- No automated tests were executed for this change.
- The file `quail/purge.py` was updated and committed as part of the change.
- Manual inspection and a quick run of repository commands were used to verify the diff applied cleanly.
- TODO: add unit tests for purge behavior and a safe dry-run mode to verify file/DB effects in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc36a32b48326b638b66c1e4bc90a)