### PR TITLE
Add optional sanitized HTML rendering for message detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,10 @@ Admin actions are gated by a shared PIN stored as a hash in the SQLite settings
 table (`admin_pin_hash`). Session unlocks are short-lived and require the PIN
 again after expiration. TODO: provide a supported setup flow for the initial
 PIN.
+
+## HTML rendering
+
+Message detail pages default to plaintext. Admins can enable sanitized HTML
+rendering in settings; HTML is cleaned before display and remote images are
+blocked. If HTML rendering is disabled or missing, Quail falls back to
+plaintext.

--- a/quail/templates/message.html
+++ b/quail/templates/message.html
@@ -22,8 +22,13 @@
   <dd>{{ "Yes" if message.quarantined else "No" }}</dd>
   {% endif %}
 </dl>
+{% if allow_html and html_body %}
+<h2>Body (sanitized HTML)</h2>
+<div class="message-html">{{ html_body | safe }}</div>
+{% else %}
 <h2>Body (text/plain)</h2>
 <pre>{{ body }}</pre>
+{% endif %}
 <h2>Attachments</h2>
 {% if attachments %}
 <ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn==0.30.1
 jinja2==3.1.4
 python-multipart==0.0.9
 argon2-cffi==23.1.0
+bleach==6.1.0


### PR DESCRIPTION
### Motivation
- Provide an admin-controlled, safer way to view HTML email bodies while preserving the default plaintext-only behavior.
- Sanitize any HTML before rendering to avoid XSS and block remote resources per project security constraints.
- Keep remote images and other external resources blocked and ensure a plaintext fallback when HTML is disabled.

### Description
- Add `bleach` to `requirements.txt` and introduce `_sanitize_html` with an allow-list of tags/attributes/protocols in `quail/web.py`.
- Update `_parse_message_body` to optionally extract a `text/html` part when `allow_html` is enabled and return `(body, attachments, html_body)`.
- In the message handler `message_detail`, load the `allow_html` setting via `db.get_setting(...)`, sanitize the HTML when present, and pass `html_body`/`allow_html` to the template.
- Modify `quail/templates/message.html` to render the sanitized HTML (`{{ html_body | safe }}`) when `allow_html` is true and `html_body` exists, otherwise fall back to plaintext; update `README.md` to document the behavior.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fc36b82a48326b763187f46eb5006)