### PR TITLE
Default bind host: use 127.0.0.1 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ alongside each message.
 ## Configuration
 
 Copy `config/config.example.env` to `/etc/quail/config.env` and adjust values as
-needed. The default bind host in the example config is `192.168.0.252` to match
-your VPN-accessible IP; update it if your server uses a different address.
+needed. The default bind host in the example config is `127.0.0.1` so the service
+binds locally; configure any reverse proxy, DNS, or static IP separately if you
+need external access.
 
 ## Admin access
 


### PR DESCRIPTION
### Motivation

- The service UI should bind to localhost by default for safety and to follow the project security constraint that the UI not be publicly accessible. 
- The README previously referenced `192.168.0.252`, which implies a host-level VPN IP and may encourage unsafe public binding. 
- Users who need external access must configure a reverse proxy, DNS, or a static IP separately rather than changing the service default. 

### Description

- Updated `README.md` to replace the `192.168.0.252` example with `127.0.0.1` as the default bind host. 
- Added a concise note advising operators to configure any reverse proxy, DNS, or static IP separately for external access. 
- The change is limited to documentation and references `config/config.example.env` and `/etc/quail/config.env` for configuration guidance. 

### Testing

- This is a documentation-only change and no automated tests were executed. 
- The change was committed to the working branch and the modified file is `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960ff746f688326950d494059efbee2)