### PR TITLE
Add docs directory placeholder

### DIFF
--- a/docs/.gitkeep
+++ b/docs/.gitkeep
@@ -1,0 +1,1 @@
+# Docs directory placeholder


### PR DESCRIPTION
### Motivation
- Provide a tracked `docs/` directory so project documentation can be added and versioned.
- Ensure an otherwise-empty directory is preserved in Git by including a minimal placeholder file.

### Description
- Add `docs/.gitkeep` containing `# Docs directory placeholder` to make the `docs/` directory trackable.
- No other source files or configuration were changed.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961308970a8832696a80aaa9911b7bc)