### PR TITLE
Fix Ruff invocation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
           pip install -r requirements.txt
           pip install black ruff pytest
       - name: Lint with Ruff
-        run: ruff .
+        run: ruff check .
       - name: Check formatting with Black
         run: black --check .
       - name: Run tests


### PR DESCRIPTION
### Motivation

- Fix CI lint failures caused by newer Ruff releases requiring an explicit subcommand, as reported in issue #24.
- Ensure the GitHub Actions lint step invokes Ruff explicitly to prevent unrecognized command errors.

### Description

- Update `.github/workflows/ci.yml` to change the lint step from `ruff .` to `ruff check .`.
- Changes were committed on branch `codex/fix-ruff-lint-ci` with message `Fix Ruff invocation in CI`.

### Testing

- No automated tests were run as part of this change.
- The CI workflow will run on push or pull request and should now execute the lint step with `ruff check .` without error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961471db000832697985ee2e0e907c2)