### PR TITLE
Add basic pytest smoke tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest configuration for Quail."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,37 @@
+"""Basic smoke tests for Quail."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from quail import db, settings
+
+
+def test_init_db_creates_tables(tmp_path):
+    db_path = tmp_path / "quail.db"
+    db.init_db(db_path)
+
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name"
+        ).fetchall()
+
+    table_names = {row[0] for row in rows}
+
+    assert "messages" in table_names
+    assert "attachments" in table_names
+    assert "settings" in table_names
+    assert "admin_actions" in table_names
+    assert "admin_rate_limits" in table_names
+
+
+def test_get_retention_days_sets_default(tmp_path):
+    db_path = tmp_path / "quail.db"
+    db.init_db(db_path)
+
+    retention = settings.get_retention_days(db_path)
+
+    assert retention == settings.DEFAULT_RETENTION_DAYS
+    assert db.get_setting(db_path, settings.SETTINGS_RETENTION_DAYS_KEY) == str(
+        settings.DEFAULT_RETENTION_DAYS
+    )


### PR DESCRIPTION
### Motivation

- Ensure pytest collects and runs tests in CI so the suite no longer fails with “collected 0 items”, addressing issue #26.
- Provide a minimal, non-invasive test surface that does not require external services or change runtime behavior.
- Give basic verification of core components (database schema and retention default) to match project acceptance criteria.

### Description

- Add `tests/conftest.py` to insert the repository root onto `sys.path` so the local `quail` package is importable in tests.
- Add `tests/test_smoke.py` with `test_init_db_creates_tables` and `test_get_retention_days_sets_default` that exercise `quail.db` and `quail.settings`.
- Tests are isolated to temporary filesystem paths and only use declared dependencies, with no application behavior changes.

### Testing

- Ran `pytest` locally which collected 2 items and reported `2 passed`.
- The added tests execute without requiring network services or external daemons and are expected to pass in CI's `Run pytest` step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69614ed143908326b5faf686b070d091)