### PR TITLE
Rename and refine spam mitigation plan documentation

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -5,6 +5,7 @@
 - [Glossary](GLOSSARY.md): Definitions of domain‑specific terms used in this project.
 - [Status](STATUS.md): Current state of the project, known issues and next milestones.
 - [Roadmap](ROADMAP.md): Planned features and near‑term objectives.
+- [Spam Mitigation Plan](QUAIL_SPAM_MITIGATION_PLAN.md): Phased plan for spam-mitigation admin controls.
 - [Change Log](../CHANGELOG.md): A human‑readable history of changes.
 - [Todo List](../TODO.md): Outstanding tasks and areas requiring attention.
 - [Architecture Decision Records](adr/0000-template.md): Template and directory for recording architectural decisions.


### PR DESCRIPTION
### Motivation

- Implement issue #28 by renaming and clarifying the repository spam mitigation plan and linking it from the docs index.
- Align the document with the authoritative constraints in `QUAIL_CODEX_CONTEXT.md` and the workflow in `CODEX.md` without adding requirements.
- Keep the change minimal and documentation-only to provide a clear execution contract for future implementation phases.

### Description

- Renamed `docs/quail_spam_mitigation_plan.md` to `docs/QUAIL_SPAM_MITIGATION_PLAN.md` and refreshed wording and formatting for clarity.
- Updated `docs/INDEX.md` to add a link to `QUAIL_SPAM_MITIGATION_PLAN.md` so the plan appears in the documentation index.
- No functional code, configuration, or behavioral changes were made; this is purely a documentation update.

### Testing

- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696154fe3e3083269092d7b3c84841a0)