### PR TITLE
Add phase 1 spam mitigation schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Added spam mitigation phase 1 schema tables and message metadata columns.
+
 ## [0.1.0] - 2026-01-09
 
 ### Added


### PR DESCRIPTION
### Motivation

- Implement Phase 1 of the spam mitigation plan from `docs/QUAIL_SPAM_MITIGATION_PLAN.md` by adding database structures required for domain policies and address rules.
- Persist ingest decision metadata and message status alongside the existing legacy `quarantined` flag to support a safe migration path.

### Description

- Added new schema entries in `quail/db.py` to create `domain_policy` and `address_rule` tables with the fields described in the Phase 1 plan.
- Extended the `messages` table schema to include `status`, `quarantine_reason`, and `ingest_decision_meta` columns while preserving the existing `quarantined` column.
- Added a migration helper `_ensure_message_columns(conn)` invoked from `init_db` to `ALTER TABLE` and add missing message columns on existing databases.
- Updated `CHANGELOG.md` with an Unreleased entry describing the schema additions.

### Testing

- No automated tests were run as part of this change (schema-only change).
- To exercise the schema/migration locally run: `python -c "from quail.db import init_db; from pathlib import Path; init_db(Path('test.db'))"` which will create the tables and add missing columns.
- All changes are additive and use defaults to avoid runtime behavior changes; further integration tests will be added in subsequent phases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69615c48e0a483268b9742d4d3ee7c19)