### PR TITLE
Fix Postfix ingest to use Quail venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to this project will be documented in this file. This projec
 - Added purge retention for admin audit entries (30 days).
 - Added pytest to requirements to run the test suite locally.
 
+### Fixed
+
+- Ensured Postfix ingest uses the Quail virtual environment interpreter with a clear error when missing.
+
 ## [0.1.0] - 2026-01-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ and install/upgrade automation are still stubbed with TODOs.
 ## Ingest
 
 Postfix should pipe messages to `scripts/quail-ingest`, which runs the ingest
-module and stores raw `.eml` files plus metadata in SQLite.
+module with the `/opt/quail/venv` interpreter and stores raw `.eml` files plus
+metadata in SQLite.
 Oversize messages are rejected at SMTP via Postfix and dropped by the ingest
 pipeline when they exceed the configured maximum size. Allowed attachments are
 extracted into the attachment directory, and attachment metadata is stored

--- a/scripts/quail-ingest
+++ b/scripts/quail-ingest
@@ -1,4 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-exec /usr/bin/env python3 -m quail.ingest "$@"
+VENV_PYTHON="/opt/quail/venv/bin/python"
+
+if [[ ! -x "${VENV_PYTHON}" ]]; then
+  message="ERROR: ${VENV_PYTHON} not found or not executable; cannot run quail.ingest."
+  echo "${message}" >&2
+  if command -v logger >/dev/null 2>&1; then
+    logger -t quail-ingest "${message}"
+  fi
+  exit 1
+fi
+
+exec "${VENV_PYTHON}" -m quail.ingest "$@"


### PR DESCRIPTION
### Motivation

- The Postfix pipe previously invoked `python3 -m quail.ingest` under the system Python and could raise `ModuleNotFoundError` because Quail is installed into `/opt/quail/venv`.
- The ingest process must run with the same interpreter/environment Quail was installed into to avoid runtime import failures.
- Provide a clear failure mode that logs an explicit error and exits non-zero if the venv interpreter is missing so Postfix will surface the failure.
- Keep the change minimal and limited to the Postfix ingest wrapper and related documentation.

### Description

- Updated `scripts/quail-ingest` to `exec` `/opt/quail/venv/bin/python -m quail.ingest` and to check that the venv python is present and executable before running.
- Added a clear error message and `logger -t quail-ingest` invocation when the venv interpreter is not found, and exit with non-zero status to signal failure.
- Documented the venv-based ingest expectation in `README.md` and recorded the fix in `CHANGELOG.md`.
- The change touches only the ingest wrapper and docs; executable bit on `scripts/quail-ingest` is preserved.

### Testing

- No automated tests were executed in this environment because Postfix and the Quail runtime are not available here, so runtime delivery could not be verified.
- No existing unit/CI tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a710d6108326a445d13bf4976b49)