### PR TITLE
Configure Postfix transport maps during install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. This projec
 - Added ingest decision logging, admin audit detail fields, and ingest visibility metrics in the admin UI.
 - Added purge retention for admin audit entries (30 days).
 - Added pytest to requirements to run the test suite locally.
+- Added Postfix transport map configuration and domain list support to `install.sh`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ decision, reason, recipient details, and sender domain for operator visibility.
 Copy `config/config.example.env` to `/etc/quail/config.env` and adjust values as
 needed. The default bind host in the example config is `127.0.0.1`, so the
 service binds to localhost unless you change it; use a reverse proxy and DNS if
-you need external access.
+you need external access. `QUAIL_DOMAINS` controls the comma-separated list of
+domains that `install.sh` registers in Postfix transport maps and catch-all
+aliases (default: `m.cst.ro`).
 
 ## Admin access
 

--- a/config/config.example.env
+++ b/config/config.example.env
@@ -4,5 +4,6 @@ QUAIL_EML_DIR=/var/lib/quail/eml
 QUAIL_ATTACHMENT_DIR=/var/lib/quail/att
 QUAIL_DB_PATH=/var/lib/quail/quail.db
 QUAIL_MAX_MESSAGE_SIZE_MB=10
+QUAIL_DOMAINS=m.cst.ro
 QUAIL_BIND_HOST=127.0.0.1
 QUAIL_BIND_PORT=8000


### PR DESCRIPTION
### Motivation
- The installer should fully configure Postfix so a fresh VM -> clone -> `install.sh` flow requires no manual `transport_maps` fiddling. 
- Support configuring multiple domains declaratively so Quail can own catch-all addresses for each configured domain. 
- Be idempotent so re-running `install.sh` does not duplicate Postfix entries. 
- Work on minimal Ubuntu images by ensuring required logging services are present.

### Description
- Updated `install.sh` to install `rsyslog` and enable it during install. 
- Added `QUAIL_DOMAINS` to `config/config.example.env` and made `install.sh` parse a comma-separated domain list into `quail_domains`. 
- `install.sh` now configures Postfix via `postconf` for `virtual_alias_domains`, `virtual_alias_maps`, `message_size_limit`, and `transport_maps`; it writes idempotent entries into `/etc/postfix/virtual` (`@<domain> quail`) and `/etc/postfix/transport` (`<domain> quail:`), runs `postmap` on both, and appends the Quail `master.cf` pipe snippet if missing. 
- Documented the new `QUAIL_DOMAINS` behavior in `README.md` and recorded the change in `CHANGELOG.md`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963a994b6188326ac82f6d208f367bc)