### PR TITLE
Document systemd override workflow and add example drop-in

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -14,6 +14,17 @@ This runbook provides step‑by‑step instructions for installing, configuring,
    - Install and enable systemd units for the service and purge timer【104907567664902†L190-L199】.
 4. **Verify installation:** Ensure that the `quail.service` and `quail-purge.timer` units are active using `systemctl status`.
 
+### Systemd overrides
+
+- Prefer editing `/etc/quail/config.env` for runtime configuration such as bind
+  host/port values.
+- If you need a systemd override, use `sudo systemctl edit quail` to create
+  `/etc/systemd/system/quail.service.d/override.conf`.
+- An example drop-in lives at `systemd/quail.service.d/override.conf.example`
+  for common overrides (such as bind host); copy it into
+  `/etc/systemd/system/quail.service.d/override.conf` if needed and reload
+  systemd afterwards.
+
 ## Upgrade
 
 To upgrade Quail to a newer version:

--- a/systemd/quail.service.d/override.conf.example
+++ b/systemd/quail.service.d/override.conf.example
@@ -1,0 +1,11 @@
+# Example systemd drop-in for Quail.
+# Prefer /etc/quail/config.env for runtime settings.
+# To use this file:
+#   sudo install -d /etc/systemd/system/quail.service.d
+#   sudo cp /opt/quail/systemd/quail.service.d/override.conf.example \
+#     /etc/systemd/system/quail.service.d/override.conf
+#   sudo systemctl daemon-reload
+#   sudo systemctl restart quail.service
+
+[Service]
+Environment="QUAIL_BIND_HOST=0.0.0.0"


### PR DESCRIPTION
### Motivation

- Clarify the intended systemd override workflow to avoid confusion from `systemctl edit` and temporary editor behavior. 
- Encourage runtime configuration to be centralized in `/etc/quail/config.env` so operators don't need ad-hoc drop-ins. 
- Provide a safe, in-repo example drop-in to demonstrate a common override (bind host) without enabling it by default.

### Description

- Add a `Systemd overrides` section to `docs/RUNBOOK.md` that documents preferring `/etc/quail/config.env`, how to use `systemctl edit quail`, and the drop-in path. 
- Add an example drop-in file at `systemd/quail.service.d/override.conf.example` showing `Environment="QUAIL_BIND_HOST=0.0.0.0"`. 
- Create the `systemd/quail.service.d/` directory and commit the new example file and runbook changes.

### Testing

- No automated tests were run because this is a documentation and example-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963ad531aac83268b8e6fcf50223908)