### PR TITLE
Update Postfix install to preserve envelope recipients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file. This projec
 ### Fixed
 
 - Ensured Postfix ingest uses the Quail virtual environment interpreter with a clear error when missing.
+- Updated Postfix install configuration to use relay domains with transport maps instead of virtual aliases, preserving envelope recipients.
 
 ## [0.1.0] - 2026-01-09
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Copy `config/config.example.env` to `/etc/quail/config.env` and adjust values as
 needed. The default bind host in the example config is `127.0.0.1`, so the
 service binds to localhost unless you change it; use a reverse proxy and DNS if
 you need external access. `QUAIL_DOMAINS` controls the comma-separated list of
-domains that `install.sh` registers in Postfix transport maps and catch-all
-aliases (default: `m.cst.ro`).
+domains that `install.sh` registers in Postfix transport maps and relay domains
+(default: `m.cst.ro`).
 
 ## Admin access
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -10,7 +10,7 @@ This runbook provides step‑by‑step instructions for installing, configuring,
    - Install necessary OS packages.
    - Create a system user and the `/var/lib/quail/{eml,att}` directories.
    - Create a Python virtual environment and install dependencies.
-   - Install Postfix catch‑all configuration snippets.
+   - Install Postfix relay/transport configuration for the Quail domain.
    - Install and enable systemd units for the service and purge timer【104907567664902†L190-L199】.
 4. **Verify installation:** Ensure that the `quail.service` and `quail-purge.timer` units are active using `systemctl status`.
 
@@ -43,6 +43,8 @@ To upgrade Quail to a newer version:
 ## Troubleshooting
 
 - **Service fails to start:** Check `/var/log/syslog` for errors. Common issues include invalid configuration values or missing directories. Ensure that Postfix is piping messages to `scripts/quail-ingest` as expected【819940561035949†L14-L16】.
-- **Email not ingested:** Verify that Postfix is configured to accept mail for `m.cst.ro` and that the ingest script has execute permission.
+- **Email not ingested:** Verify that Postfix is configured to accept mail for
+  `m.cst.ro` via `relay_domains` and `transport_maps`, and that the ingest
+  script has execute permission.
 - **Admin PIN lost:** Reset the PIN by updating the `admin_pin_hash` in the SQLite settings table. Use a secure Argon2 hash generator.
 - **Attachment quarantined unexpectedly:** Check the allowed MIME types in the settings and adjust as necessary【104907567664902†L71-L78】.

--- a/postfix/maincf.snippet
+++ b/postfix/maincf.snippet
@@ -1,5 +1,5 @@
 # Quail catch-all transport
-virtual_alias_domains = m.cst.ro
-virtual_alias_maps = hash:/etc/postfix/virtual
+relay_domains = m.cst.ro
+transport_maps = hash:/etc/postfix/transport
 # 10 MB; keep in sync with QUAIL_MAX_MESSAGE_SIZE_MB if customized.
 message_size_limit = 10485760


### PR DESCRIPTION
### Motivation

- Ensure a fresh Ubuntu install pipes mail for `m.cst.ro` into Quail while preserving the original envelope recipient.
- Virtual alias rewriting previously ran before transport lookup and could bypass the Quail pipe transport, breaking ingest semantics.
- Align `install.sh` and shipped Postfix snippets with the authoritative deploy expectations (idempotent install, minimal post-install work).

### Description

- Replace virtual aliasing with `relay_domains` and `transport_maps` in `postfix/maincf.snippet` so Postfix will use transport lookup for Quail domains.
- Update `install.sh` to stop generating `/etc/postfix/virtual`, to apply `postconf` entries from `postfix/maincf.snippet` idempotently, to ensure `relay_domains`/`transport_maps` are present, and to run `postmap /etc/postfix/transport` and reload Postfix.
- Remove the virtual alias map handling and add a comment in `install.sh` explaining why virtual aliasing is not used to preserve envelope recipients for the pipe transport.
- Update `README.md`, `docs/RUNBOOK.md`, and `CHANGELOG.md` to document the relay/transport configuration change.

### Testing

- No automated tests were run as part of this change.
- CI (lint/test) will run on push and should report pass/fail for the repository test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963b6a67e8c832698020047b6de8db3)